### PR TITLE
Add manual lower min Python version to avoid conflict w/old Spyder

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch: python
-  number: 1002
+  number: 1003
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -22,7 +22,7 @@ requirements:
     - setuptools
     - pip
   run:
-    - python >={{ python_min }}
+    - python >=3.5
     - spyder >=3.2
     - pweave
     - qtpy


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* ~Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

PR #13 adopted the standardized minimum version syntax of CFEP-25, but given Spyder-Reports currently only supports Spyder <4 which won't run on newer Pythons supported by CF, we need to manually add a lower Python version bound at runtime so that it can be installed together with the Spyder versions it supports (with appropriate user-supplied constraints).